### PR TITLE
Updates to rich text input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ This is a godot plugin that helps to display user registered actions and control
 - **InputIconTextureRect**: A new control node that displays icons registered with the input icons plugin.
   - Helps developers visualize their input icon textures for different input types in the editor as well as responds to changes in values at runtime
   - Select from list of registered user inputs
+- **InputIconRichTextLabel**: A new control node that renders input icons inline with text using `[action:NAME]` tokens.
+  - Mix action icons with regular BBCode text, with multiple actions per label
+  - Each token resolves to the icon for the current display device
 - **InputIconResolver**: A godot object that can be instantiated to resolve input icons at runtime
   - Supports modifier keys (shift, ctrl, etc)
 - **Remap Input Demo**: A demo of how to use this plugin to remap inputs and display their icons in game
@@ -44,7 +47,9 @@ This is a godot plugin that helps to display user registered actions and control
 
 ## 📝 How to use
 
-The plugin is usable out of the box without doing anything but using the new control node.
+The plugin is usable out of the box without doing anything but using the new control nodes.
+
+### Using the InputIconTextureRect
 
 1. Add the `InputIconTextureRect` to your scene
 2. Click on it and open the inspector there will be 3 properties
@@ -52,6 +57,28 @@ The plugin is usable out of the box without doing anything but using the new con
    - Display Device: The device to use when choosing what input type to display in the texture
    - Action Index: The index of the registered user input action to use when choosing which icon to display in the texture
    - Action Name: A user registered action name (select from registered actions!)
+
+### Using the InputIconRichTextLabel
+
+The `InputIconRichTextLabel` renders input icons *inline* with text. Add the node to your scene and set its text using `[action:NAME]` tokens. Each token is replaced with the icon for that action on the current display device.
+
+```txt
+Use [action:attack] to attack and [action:jump] to jump!
+```
+
+It has the following properties:
+
+- **Display Device**: The device to use when choosing which input type to display.
+- **Icon Size**: The height (in pixels) icons are scaled to; width scales to keep the aspect ratio.
+- **Show Action Name When Missing Icon**: When an action has no icon, fall back to showing its name as text.
+
+Notes:
+
+- Regular [BBCode](https://docs.godotengine.org/en/stable/tutorials/ui/bbcode_in_richtextlabel.html) works alongside tokens, e.g. `[b]Press[/b] [action:jump]`.
+- If an action has multiple bindings for a device, choose one with a trailing index: `[action:jump:1]` shows the second binding (defaults to `0`).
+- Unknown action tokens are flagged with a configuration warning in the editor.
+- Set the text in the inspector or from script — assigning `text` works, and C# callers can use `set_rich_input_text()`.
+- With [Input Helper Integration](#using-input-helper-integration) enabled, the label automatically re-renders when the active device changes (keyboard ↔ controller).
 
 ### Registering your own icons
 

--- a/godot_input_icons/addons/godot_input_icons/input_icon_resolver.gd
+++ b/godot_input_icons/addons/godot_input_icons/input_icon_resolver.gd
@@ -13,14 +13,14 @@ func _init() -> void:
 
 ## Gets an icon from the plugin's registed icon map based off of the device_type
 ## and the input_action passed in
-func get_icon(device_type: InputTypes, input_action: String, index: int = 0) -> Texture2D:
+func get_icon(device_type: InputTypes, input_action: String, index: int = 0, push_warnings: bool = true) -> Texture2D:
 	var result: Texture2D = null
 	if device_type == InputTypes.Keyboard:
-		result = get_keyboard_icon(input_action, index)
+		result = get_keyboard_icon(input_action, index, push_warnings)
 		if not result and input_icon_map.unmapped_key:
 			result = input_icon_map.unmapped_key
 	else:
-		result = get_joypad_icon(device_type, input_action, index)
+		result = get_joypad_icon(device_type, input_action, index, push_warnings)
 		if not result and input_icon_map.unmapped_controller_button:
 			result = input_icon_map.unmapped_controller_button
 	return result
@@ -28,8 +28,8 @@ func get_icon(device_type: InputTypes, input_action: String, index: int = 0) -> 
 
 ## Gets the keyboard icon for the first keyboard input associated with
 ## an action
-func get_keyboard_icon(input_action: String, index: int = 0) -> Texture2D:
-	var input_event: InputEvent = get_keyboard_input_event_for_action(input_action, index)
+func get_keyboard_icon(input_action: String, index: int = 0, push_warnings: bool = true) -> Texture2D:
+	var input_event: InputEvent = get_keyboard_input_event_for_action(input_action, index, push_warnings)
 	var textures: Array[Texture2D] = []
 	# Add modifiers first
 	if input_event is InputEventWithModifiers:
@@ -88,14 +88,15 @@ func get_mouse_button_icon(input_event: InputEventMouseButton) -> Texture2D:
 
 ## Gets the controller icon for the first controller input associated with
 ## an action
-func get_joypad_icon(device_type: InputTypes, input_action: String, index: int = 0) -> Texture2D:
+func get_joypad_icon(device_type: InputTypes, input_action: String, index: int = 0, push_warnings: bool = true) -> Texture2D:
 	if not input_icon_map.controller_icons.has(device_type):
-		push_warning("InputIcons: Missing icon map for device %s" % \
-			[get_device_type_display(device_type)])
+		if push_warnings:
+			push_warning("InputIcons: Missing icon map for device %s" % \
+				[get_device_type_display(device_type)])
 		return null
-		
+
 	var joypad_icon_map: ControllerIcons = input_icon_map.controller_icons.get(device_type)
-	var input_event: InputEvent = get_joypad_input_event_for_action(input_action, index)
+	var input_event: InputEvent = get_joypad_input_event_for_action(input_action, index, push_warnings)
 	if input_event is InputEventJoypadButton:
 		return _get_joypad_button_icon(joypad_icon_map, input_event)
 	elif input_event is InputEventJoypadMotion:
@@ -129,12 +130,13 @@ func get_input_events_for_action(input_action: String) -> Array[InputEvent]:
 ## - returns null if no actions are found
 ## NOTE: The index applies to only input events for keyboard and will be
 ## in the same order that they are registered in the ProjectSettings input	
-func get_keyboard_input_event_for_action(input_action: String, index: int = 0) -> InputEvent:
+func get_keyboard_input_event_for_action(input_action: String, index: int = 0, push_warnings: bool = true) -> InputEvent:
 	var events: Array[InputEvent] = get_input_events_for_action(input_action)
 	var filtered_events: Array[InputEvent] = events.filter(func(event): return event is InputEventKey or event is InputEventMouseButton)
 	if not filtered_events or index >= filtered_events.size():
-		push_warning("InputIcons: keyboard action '%s' at index %s not found." % \
-			 [input_action, index])
+		if push_warnings:
+			push_warning("InputIcons: keyboard action '%s' at index %s not found." % \
+				 [input_action, index])
 		return null
 	return filtered_events[index]
 	
@@ -144,13 +146,14 @@ func get_keyboard_input_event_for_action(input_action: String, index: int = 0) -
 ## - returns null if no actions are found
 ## NOTE: The index applies to only input events for joypad and will be
 ## in the same order that they are registered in the ProjectSettings input 
-func get_joypad_input_event_for_action(input_action: String, index: int = 0) -> InputEvent:
+func get_joypad_input_event_for_action(input_action: String, index: int = 0, push_warnings: bool = true) -> InputEvent:
 	var events: Array[InputEvent] = get_input_events_for_action(input_action)
 	var filtered_events = events.filter(func(event): return event is InputEventJoypadButton \
 		 or event is InputEventJoypadMotion)
 	if not filtered_events or index >= filtered_events.size():
-		push_warning("InputIcons: joypad action '%s' at index %s not found." % \
-			 [input_action, index])
+		if push_warnings:
+			push_warning("InputIcons: joypad action '%s' at index %s not found." % \
+				 [input_action, index])
 		return null
 	return filtered_events[index]
 	

--- a/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
+++ b/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
@@ -5,7 +5,7 @@ extends RichTextLabel
 @export var display_device: InputIconConstants.InputTypes = InputIconConstants.InputTypes.Keyboard:
 	set(value):
 		display_device = value
-		_render_from_raw_text()
+		_request_render()
 
 const TOKEN_PREFIX := "[action:"
 const TOKEN_SUFFIX := "]"
@@ -13,12 +13,15 @@ const TOKEN_SUFFIX := "]"
 @export var icon_size: int = 32:
 	set(value):
 		icon_size = value
-		_render_from_raw_text()
+		_request_render()
 
 var _icon_resolver: InputIconResolver = InputIconResolver.new()
 var input_helper_adapter: InputHelperAdapter = null
 var is_input_helper_adapter_enabled: bool = false
 var _raw_text: String = ""
+
+const RENDER_DEBOUNCE_SECONDS := 0.5
+var _render_debounce_timer: Timer = null
 
 #region Editor custom property variables
 var _action_property_name: String = "action_name"
@@ -36,6 +39,12 @@ func _init() -> void:
 
 func _ready() -> void:
 	bbcode_enabled = true
+	if Engine.is_editor_hint():
+		_render_debounce_timer = Timer.new()
+		_render_debounce_timer.one_shot = true
+		_render_debounce_timer.timeout.connect(_render_from_raw_text)
+		# Internal so it isn't saved into the user's scene or shown in the tree.
+		add_child(_render_debounce_timer, false, Node.INTERNAL_MODE_FRONT)
 	if is_input_helper_adapter_enabled and enable_input_helper:
 		input_helper_adapter = InputHelperAdapter.new(action_name, _render_from_raw_text, set_display_device)
 		input_helper_adapter.device_indexes = device_indexes
@@ -60,7 +69,7 @@ func get_rich_input_text() -> String:
 func _set(property: StringName, value: Variant) -> bool:
 	if property == "text":
 		_raw_text = str(value)
-		_render_from_raw_text()
+		_request_render()
 		return true
 	return false
 
@@ -68,6 +77,15 @@ func _get(property: StringName) -> Variant:
 	if property == "text":
 		return _raw_text
 	return null
+
+## Debounced entry point for re-rendering; restarts a single timer so a burst of
+## edits only renders once, after the text settles.
+func _request_render() -> void:
+	# No timer outside the editor: render immediately. In the editor, debounce.
+	if _render_debounce_timer == null:
+		_render_from_raw_text()
+		return
+	_render_debounce_timer.start(RENDER_DEBOUNCE_SECONDS)
 
 func _render_from_raw_text() -> void:
 	if not is_inside_tree():
@@ -132,9 +150,8 @@ func set_action_property_value(value: Variant) -> void:
 	action_name = value
 	if input_helper_adapter != null:
 		input_helper_adapter.action_name = value
-	_render_from_raw_text()
+	_request_render()
 
 ## Sets the display_device and updates the controls texture
 func set_display_device(value: InputIconConstants.InputTypes) -> void:
 	display_device = value
-	_render_from_raw_text()

--- a/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
+++ b/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
@@ -23,17 +23,6 @@ var _raw_text: String = ""
 const RENDER_DEBOUNCE_SECONDS := 0.35
 var _render_debounce_timer: Timer = null
 
-#region Editor custom property variables
-var _action_property_name: String = "action_name"
-var _action_property_default: StringName = "--select--"
-var action_name: StringName = _action_property_default: set = set_action_property_value
-var device_indexes: PackedInt32Array = []
-## User override for disabling the helper for this node instance while
-## keeping the adapter enabled for the entire plugin.
-## NOTE: Done by overriding _get_property_list, _get, _set, etc
-var enable_input_helper: bool = true
-#endregion
-
 func _init() -> void:
 	is_input_helper_adapter_enabled = ProjectSettings.get_setting(InputIconConstants.INPUT_HELPER_ADAPTER_SETTING_NAME, false)
 
@@ -45,9 +34,8 @@ func _ready() -> void:
 		_render_debounce_timer.timeout.connect(_render_from_raw_text)
 		# Internal so it isn't saved into the user's scene or shown in the tree.
 		add_child(_render_debounce_timer, false, Node.INTERNAL_MODE_FRONT)
-	if is_input_helper_adapter_enabled and enable_input_helper:
-		input_helper_adapter = InputHelperAdapter.new(action_name, _render_from_raw_text, set_display_device)
-		input_helper_adapter.device_indexes = device_indexes
+	if is_input_helper_adapter_enabled:
+		input_helper_adapter = InputHelperAdapter.new("", _render_from_raw_text, set_display_device)
 		
 	# If text was set in editor/scene, treat it as initial raw text.
 	if _raw_text.is_empty() and not text.is_empty():
@@ -182,12 +170,6 @@ func _get_configuration_warnings() -> PackedStringArray:
 		return []
 	return ["Unknown action(s): %s\nRegistered actions: %s" % \
 		[", ".join(unknown), ", ".join(registered)]]
-
-func set_action_property_value(value: Variant) -> void:
-	action_name = value
-	if input_helper_adapter != null:
-		input_helper_adapter.action_name = value
-	_request_render()
 
 ## Sets the display_device and updates the controls texture
 func set_display_device(value: InputIconConstants.InputTypes) -> void:

--- a/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
+++ b/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
@@ -7,11 +7,6 @@ extends RichTextLabel
 		display_device = value
 		_render_from_raw_text()
 
-@export var action_index: int = 0:
-	set(value):
-		action_index = value
-		_render_from_raw_text()
-
 const TOKEN_PREFIX := "[action:"
 const TOKEN_SUFFIX := "]"
 @export var show_action_name_when_missing_icon := true
@@ -110,11 +105,21 @@ func _append_parsed(input: String) -> void:
 		_append_action(action)
 		i = end + s_len
 
-func _append_action(action: String) -> void:
+func _append_action(token: String) -> void:
+	if token.is_empty():
+		return
+
+	var action := token
+	var index := 0
+	var sep := token.rfind(":")
+	if sep != -1 and token.substr(sep + 1).is_valid_int():
+		action = token.substr(0, sep).strip_edges()
+		index = token.substr(sep + 1).to_int()
+
 	if action.is_empty():
 		return
 
-	var icon: Texture2D = _icon_resolver.get_icon(display_device, StringName(action), action_index)
+	var icon: Texture2D = _icon_resolver.get_icon(display_device, StringName(action), index)
 	if icon:
 		# Constrain height so every icon shares the text line-height; width scales.
 		add_image(icon, 0, icon_size)

--- a/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
+++ b/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
@@ -79,13 +79,14 @@ func _render_from_raw_text() -> void:
 		return
 
 	clear()
-	append_text(_parse_to_bbcode(_raw_text))
+	_append_parsed(_raw_text)
 
-func _parse_to_bbcode(input: String) -> String:
+## Walks the raw text, appending plain segments as BBCode and replacing each
+## [action:<name>] token with its resolved icon.
+func _append_parsed(input: String) -> void:
 	if input.is_empty():
-		return ""
+		return
 
-	var out := ""
 	var i := 0
 	var p_len := TOKEN_PREFIX.length()
 	var s_len := TOKEN_SUFFIX.length()
@@ -93,35 +94,34 @@ func _parse_to_bbcode(input: String) -> String:
 	while i < input.length():
 		var start := input.find(TOKEN_PREFIX, i)
 		if start == -1:
-			out += input.substr(i)
+			append_text(input.substr(i))
 			break
 
 		if start > i:
-			out += input.substr(i, start - i)
+			append_text(input.substr(i, start - i))
 
 		var action_start := start + p_len
 		var end := input.find(TOKEN_SUFFIX, action_start)
 		if end == -1:
-			out += input.substr(start)
+			append_text(input.substr(start))
 			break
 
 		var action := input.substr(action_start, end - action_start).strip_edges()
-		out += _action_to_bbcode(action)
+		_append_action(action)
 		i = end + s_len
 
-	return out
-
-func _action_to_bbcode(action: String) -> String:
+func _append_action(action: String) -> void:
 	if action.is_empty():
-		return ""
+		return
 
 	var icon: Texture2D = _icon_resolver.get_icon(display_device, StringName(action), action_index)
-	if icon and icon.resource_path != "":
-		return "[img=" + str(icon_size) + "]%s[/img]" % icon.resource_path
+	if icon:
+		# Constrain height so every icon shares the text line-height; width scales.
+		add_image(icon, 0, icon_size)
+		return
 
 	if show_action_name_when_missing_icon:
-		return action
-	return ""
+		append_text(action)
 
 func set_action_property_value(value: Variant) -> void:
 	action_name = value

--- a/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
+++ b/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
@@ -12,8 +12,8 @@ extends RichTextLabel
 		action_index = value
 		_render_from_raw_text()
 
-@export var token_prefix: String = "[action:"
-@export var token_suffix: String = "]"
+const TOKEN_PREFIX := "[action:"
+const TOKEN_SUFFIX := "]"
 @export var show_action_name_when_missing_icon := true
 @export var icon_size: int = 32:
 	set(value):
@@ -87,11 +87,11 @@ func _parse_to_bbcode(input: String) -> String:
 
 	var out := ""
 	var i := 0
-	var p_len := token_prefix.length()
-	var s_len := token_suffix.length()
+	var p_len := TOKEN_PREFIX.length()
+	var s_len := TOKEN_SUFFIX.length()
 
 	while i < input.length():
-		var start := input.find(token_prefix, i)
+		var start := input.find(TOKEN_PREFIX, i)
 		if start == -1:
 			out += _escape_bbcode(input.substr(i))
 			break
@@ -100,7 +100,7 @@ func _parse_to_bbcode(input: String) -> String:
 			out += _escape_bbcode(input.substr(i, start - i))
 
 		var action_start := start + p_len
-		var end := input.find(token_suffix, action_start)
+		var end := input.find(TOKEN_SUFFIX, action_start)
 		if end == -1:
 			out += _escape_bbcode(input.substr(start))
 			break

--- a/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
+++ b/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
@@ -93,16 +93,16 @@ func _parse_to_bbcode(input: String) -> String:
 	while i < input.length():
 		var start := input.find(TOKEN_PREFIX, i)
 		if start == -1:
-			out += _escape_bbcode(input.substr(i))
+			out += input.substr(i)
 			break
 
 		if start > i:
-			out += _escape_bbcode(input.substr(i, start - i))
+			out += input.substr(i, start - i)
 
 		var action_start := start + p_len
 		var end := input.find(TOKEN_SUFFIX, action_start)
 		if end == -1:
-			out += _escape_bbcode(input.substr(start))
+			out += input.substr(start)
 			break
 
 		var action := input.substr(action_start, end - action_start).strip_edges()
@@ -120,12 +120,9 @@ func _action_to_bbcode(action: String) -> String:
 		return "[img=" + str(icon_size) + "]%s[/img]" % icon.resource_path
 
 	if show_action_name_when_missing_icon:
-		return "[%s]" % _escape_bbcode(action)
+		return action
 	return ""
 
-func _escape_bbcode(s: String) -> String:
-	return s.replace("[", "\\[").replace("]", "\\]")
-	
 func set_action_property_value(value: Variant) -> void:
 	action_name = value
 	if input_helper_adapter != null:

--- a/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
+++ b/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
@@ -36,7 +36,7 @@ func _ready() -> void:
 		add_child(_render_debounce_timer, false, Node.INTERNAL_MODE_FRONT)
 	if is_input_helper_adapter_enabled:
 		input_helper_adapter = InputHelperAdapter.new("", _render_from_raw_text, set_display_device)
-		
+
 	# If text was set in editor/scene, treat it as initial raw text.
 	if _raw_text.is_empty() and not text.is_empty():
 		_raw_text = text

--- a/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
+++ b/godot_input_icons/addons/godot_input_icons/input_icon_richtextlabel.gd
@@ -20,7 +20,7 @@ var input_helper_adapter: InputHelperAdapter = null
 var is_input_helper_adapter_enabled: bool = false
 var _raw_text: String = ""
 
-const RENDER_DEBOUNCE_SECONDS := 0.5
+const RENDER_DEBOUNCE_SECONDS := 0.35
 var _render_debounce_timer: Timer = null
 
 #region Editor custom property variables
@@ -93,6 +93,8 @@ func _render_from_raw_text() -> void:
 
 	clear()
 	_append_parsed(_raw_text)
+	if Engine.is_editor_hint():
+		update_configuration_warnings()
 
 ## Walks the raw text, appending plain segments as BBCode and replacing each
 ## [action:<name>] token with its resolved icon.
@@ -127,17 +129,14 @@ func _append_action(token: String) -> void:
 	if token.is_empty():
 		return
 
-	var action := token
-	var index := 0
-	var sep := token.rfind(":")
-	if sep != -1 and token.substr(sep + 1).is_valid_int():
-		action = token.substr(0, sep).strip_edges()
-		index = token.substr(sep + 1).to_int()
-
+	var parsed := _parse_token(token)
+	var action: String = parsed[0]
+	var index: int = parsed[1]
 	if action.is_empty():
 		return
 
-	var icon: Texture2D = _icon_resolver.get_icon(display_device, StringName(action), index)
+	# Stay quiet in the editor (config warnings cover it); keep console diagnostics at runtime.
+	var icon: Texture2D = _icon_resolver.get_icon(display_device, StringName(action), index, not Engine.is_editor_hint())
 	if icon:
 		# Constrain height so every icon shares the text line-height; width scales.
 		add_image(icon, 0, icon_size)
@@ -145,6 +144,44 @@ func _append_action(token: String) -> void:
 
 	if show_action_name_when_missing_icon:
 		append_text(action)
+
+## Splits a token body like "Jump" or "Jump:1" into [action_name, binding_index].
+func _parse_token(token: String) -> Array:
+	var sep := token.rfind(":")
+	if sep != -1 and token.substr(sep + 1).is_valid_int():
+		return [token.substr(0, sep).strip_edges(), token.substr(sep + 1).to_int()]
+	return [token, 0]
+
+## Returns the unique action names referenced by [action:<name>] tokens in `input`.
+func _referenced_actions(input: String) -> PackedStringArray:
+	var actions: PackedStringArray = []
+	var i := 0
+	var p_len := TOKEN_PREFIX.length()
+	var s_len := TOKEN_SUFFIX.length()
+	while i < input.length():
+		var start := input.find(TOKEN_PREFIX, i)
+		if start == -1:
+			break
+		var action_start := start + p_len
+		var end := input.find(TOKEN_SUFFIX, action_start)
+		if end == -1:
+			break
+		var action: String = _parse_token(input.substr(action_start, end - action_start).strip_edges())[0]
+		if action != "" and action not in actions:
+			actions.append(action)
+		i = end + s_len
+	return actions
+
+func _get_configuration_warnings() -> PackedStringArray:
+	var registered := InputIconResolver.get_all_user_registered_inputs()
+	var unknown: PackedStringArray = []
+	for action in _referenced_actions(_raw_text):
+		if action not in registered:
+			unknown.append(action)
+	if unknown.is_empty():
+		return []
+	return ["Unknown action(s): %s\nRegistered actions: %s" % \
+		[", ".join(unknown), ", ".join(registered)]]
 
 func set_action_property_value(value: Variant) -> void:
 	action_name = value

--- a/godot_input_icons/main.tscn
+++ b/godot_input_icons/main.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://cipb74td5x87b"]
+[gd_scene load_steps=5 format=3 uid="uid://cipb74td5x87b"]
 
 [ext_resource type="Script" uid="uid://dofhds2ttw30" path="res://remap_input_demo/remap_example.gd" id="1_0xm2m"]
 [ext_resource type="PackedScene" uid="uid://b0ll35eulteec" path="res://remap_input_demo/remap_input_row.tscn" id="1_1bvp3"]
+[ext_resource type="Script" uid="uid://bpt8as8jhyvp1" path="res://addons/godot_input_icons/input_icon_richtextlabel.gd" id="3_1bvp3"]
 [ext_resource type="Script" uid="uid://nei7ddo8bmn0" path="res://remap_input_demo/input_helper_warning_panel.gd" id="3_h2yge"]
 
 [node name="CanvasLayer" type="CanvasLayer"]
@@ -99,3 +100,75 @@ grow_horizontal = 2
 grow_vertical = 2
 text = "Enable input helper support Project Settings > Input Icons > Settings > Use Input Helper"
 autowrap_mode = 2
+
+[node name="RichTextExample" type="Panel" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -169.0
+offset_top = -119.0
+offset_right = 169.0
+offset_bottom = 119.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+
+[node name="MarginContainer" type="MarginContainer" parent="RichTextExample"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="VBoxContainer" type="VBoxContainer" parent="RichTextExample/MarginContainer"]
+layout_mode = 2
+
+[node name="AttackRichText" type="RichTextLabel" parent="RichTextExample/MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 60)
+layout_mode = 2
+bbcode_enabled = true
+text = "Use [action:attack] or [action:attack:1] to attack!"
+vertical_alignment = 1
+script = ExtResource("3_1bvp3")
+metadata/_custom_type_script = "uid://bpt8as8jhyvp1"
+
+[node name="DefendRichText" type="RichTextLabel" parent="RichTextExample/MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 60)
+layout_mode = 2
+bbcode_enabled = true
+text = "Use [action:defend] to defend"
+vertical_alignment = 1
+script = ExtResource("3_1bvp3")
+metadata/_custom_type_script = "uid://bpt8as8jhyvp1"
+
+[node name="ExampleHBox" type="VBoxContainer" parent="."]
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_top = -20.0
+offset_right = 133.0
+offset_bottom = 20.0
+grow_vertical = 2
+
+[node name="RemapButton" type="Button" parent="ExampleHBox"]
+layout_mode = 2
+text = "Remap Example"
+
+[node name="RichTextButton" type="Button" parent="ExampleHBox"]
+layout_mode = 2
+text = "Rich Text Example"
+
+[connection signal="ready" from="RemapExample" to="RemapExample" method="show"]
+[connection signal="ready" from="RichTextExample" to="RichTextExample" method="hide"]
+[connection signal="pressed" from="ExampleHBox/RemapButton" to="RemapExample" method="show"]
+[connection signal="pressed" from="ExampleHBox/RemapButton" to="RichTextExample" method="hide"]
+[connection signal="pressed" from="ExampleHBox/RichTextButton" to="RemapExample" method="hide"]
+[connection signal="pressed" from="ExampleHBox/RichTextButton" to="RichTextExample" method="show"]

--- a/godot_input_icons/project.godot
+++ b/godot_input_icons/project.godot
@@ -94,7 +94,7 @@ attack={
 }
 defend={
 "deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":76,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":true,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":86,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 walk_up={


### PR DESCRIPTION
 - Render combined icons (modifier+key, controller overlays) via `add_image` instead of `[img=path]`
 - Scale icons by height so wide combined icons match the text line-height
 - Drop bracket-escaping so regular BBCode works in the label
 - Move the binding index into the token (`[action:jump:1]`); removed the node-wide `action_index` export
 - Make the token delimiters constants instead of exports
 - Debounce re-render in the editor to stop per-keystroke "action not found" spam
 - Add editor configuration warnings for unknown action tokens
 - Add an optional `push_warnings` flag to the resolver so the label resolves silently in-editor but keeps console diagnostics at runtime
 - Add README docs and a demo for the node